### PR TITLE
improve union type checker error message

### DIFF
--- a/__tests__/PropTypesDevelopmentReact15.js
+++ b/__tests__/PropTypesDevelopmentReact15.js
@@ -859,6 +859,24 @@ describe('PropTypesDevelopmentReact15', () => {
       typeCheckPass(PropTypes.oneOf(PropTypes.string, PropTypes.number), []);
     });
 
+    it('should warn when setup with invalid checker types', () => {
+      spyOn(console, 'error');
+
+      PropTypes.oneOfType([undefined])
+
+      expect(console.error).toHaveBeenCalled();
+      expect(console.error.calls.argsFor(0)[0])
+        .toContain('Invalid argument supplied to oneOfType. Expected an array containing check functions, but argument at index 0 is undefined.');
+
+      console.error.calls.reset();
+
+      PropTypes.oneOfType([PropTypes.string, {}])
+
+      expect(console.error).toHaveBeenCalled();
+      expect(console.error.calls.argsFor(0)[0])
+        .toContain('Invalid argument supplied to oneOfType. Expected an array containing check functions, but argument at index 1 is of type object.');
+    });
+
     it('should warn if none of the types are valid', () => {
       typeCheckFail(
         PropTypes.oneOfType([PropTypes.string, PropTypes.number]),

--- a/__tests__/PropTypesDevelopmentReact15.js
+++ b/__tests__/PropTypesDevelopmentReact15.js
@@ -859,22 +859,24 @@ describe('PropTypesDevelopmentReact15', () => {
       typeCheckPass(PropTypes.oneOf(PropTypes.string, PropTypes.number), []);
     });
 
-    it('should warn when setup with invalid checker types', () => {
+    it('should warn but for invalid argument type', () => {
       spyOn(console, 'error');
 
-      PropTypes.oneOfType([undefined])
+      var types = [undefined, null, false, new Date, /foo/, {}];
+      var expected = ['undefined', 'null', 'a boolean', 'a date', 'a regexp', 'an object'];
 
-      expect(console.error).toHaveBeenCalled();
-      expect(console.error.calls.argsFor(0)[0])
-        .toContain('Invalid argument supplied to oneOfType. Expected an array containing check functions, but argument at index 0 is undefined.');
-
-      console.error.calls.reset();
-
-      PropTypes.oneOfType([PropTypes.string, {}])
-
-      expect(console.error).toHaveBeenCalled();
-      expect(console.error.calls.argsFor(0)[0])
-        .toContain('Invalid argument supplied to oneOfType. Expected an array containing check functions, but argument at index 1 is of type object.');
+      for (var i = 0; i < expected.length; i++) {
+        var type = types[i];
+        PropTypes.oneOfType([type]);
+        expect(console.error).toHaveBeenCalled();
+        expect(console.error.calls.argsFor(0)[0]).toContain(
+          'Invalid argument supplid to oneOfType. Expected an array of check functions, ' +
+          'but received ' + expected[i] + ' at index 0.'
+        );
+        console.error.calls.reset();
+      }
+      
+      typeCheckPass(PropTypes.oneOf(PropTypes.string, PropTypes.number), []);
     });
 
     it('should warn if none of the types are valid', () => {

--- a/__tests__/PropTypesDevelopmentStandalone-test.js
+++ b/__tests__/PropTypesDevelopmentStandalone-test.js
@@ -856,25 +856,23 @@ describe('PropTypesDevelopmentStandalone', () => {
       typeCheckPass(PropTypes.oneOf(PropTypes.string, PropTypes.number), []);
     });
 
-    it('should warn but not error for invalid argument type', () => {
+    it('should warn but for invalid argument type', () => {
       spyOn(console, 'error');
 
-      PropTypes.oneOfType([undefined]);
+      var types = [undefined, null, false, new Date, /foo/, {}];
+      var expected = ['undefined', 'null', 'a boolean', 'a date', 'a regexp', 'an object'];
 
-      expect(console.error).toHaveBeenCalled();
-      expect(console.error.calls.argsFor(0)[0]).toContain(
-        'Invalid argument supplied to oneOfType. Expected an array containing check functions, but argument at index 0 is undefined.',
-      );
-
-      console.error.calls.reset();
-
-      PropTypes.oneOfType([PropTypes.string, {}]);
-
-      expect(console.error).toHaveBeenCalled();
-      expect(console.error.calls.argsFor(0)[0]).toContain(
-        'Invalid argument supplied to oneOfType. Expected an array containing check functions, but argument at index 1 is of type object.',
-      );
-
+      for (var i = 0; i < expected.length; i++) {
+        var type = types[i];
+        PropTypes.oneOfType([type]);
+        expect(console.error).toHaveBeenCalled();
+        expect(console.error.calls.argsFor(0)[0]).toContain(
+          'Invalid argument supplid to oneOfType. Expected an array of check functions, ' +
+          'but received ' + expected[i] + ' at index 0.'
+        );
+        console.error.calls.reset();
+      }
+      
       typeCheckPass(PropTypes.oneOf(PropTypes.string, PropTypes.number), []);
     });
 

--- a/__tests__/PropTypesDevelopmentStandalone-test.js
+++ b/__tests__/PropTypesDevelopmentStandalone-test.js
@@ -856,6 +856,28 @@ describe('PropTypesDevelopmentStandalone', () => {
       typeCheckPass(PropTypes.oneOf(PropTypes.string, PropTypes.number), []);
     });
 
+    it('should warn but not error for invalid argument type', () => {
+      spyOn(console, 'error');
+
+      PropTypes.oneOfType([undefined]);
+
+      expect(console.error).toHaveBeenCalled();
+      expect(console.error.calls.argsFor(0)[0]).toContain(
+        'Invalid argument supplied to oneOfType. Expected an array containing check functions, but argument at index 0 is undefined.',
+      );
+
+      console.error.calls.reset();
+
+      PropTypes.oneOfType([PropTypes.string, {}]);
+
+      expect(console.error).toHaveBeenCalled();
+      expect(console.error.calls.argsFor(0)[0]).toContain(
+        'Invalid argument supplied to oneOfType. Expected an array containing check functions, but argument at index 1 is of type object.',
+      );
+
+      typeCheckPass(PropTypes.oneOf(PropTypes.string, PropTypes.number), []);
+    });
+
     it('should warn if none of the types are valid', () => {
       typeCheckFail(
         PropTypes.oneOfType([PropTypes.string, PropTypes.number]),

--- a/__tests__/PropTypesProductionReact15-test.js
+++ b/__tests__/PropTypesProductionReact15-test.js
@@ -819,6 +819,17 @@ describe('PropTypesProductionReact15', () => {
         undefined,
       );
     });
+
+    it('should not warn if setup without checker function', () => {
+      expectNoop(
+        PropTypes.oneOfType([null]),
+        null,
+      );
+      expectNoop(
+        PropTypes.oneOfType([undefined]),
+        undefined,
+      );
+    });
   });
 
   describe('Shape Types', () => {

--- a/factoryWithTypeCheckers.js
+++ b/factoryWithTypeCheckers.js
@@ -314,6 +314,23 @@ module.exports = function(isValidElement, throwOnDirectAccess) {
       return emptyFunction.thatReturnsNull;
     }
 
+    for (var i = 0; i < arrayOfTypeCheckers.length; i++) {
+      var checker = arrayOfTypeCheckers[i];
+      if (typeof checker !== 'function') {
+        var detailMessage;
+
+        if(checker === void 0 || checker === null) {
+          detailMessage = checker;
+        }
+        else {
+          detailMessage = 'of type ' + getPreciseType(checker);
+        }
+
+        warning(false, 'Invalid argument supplied to oneOfType. Expected an array containing check functions, but argument at index ' + i + ' is ' + detailMessage + '.');
+        return emptyFunction.thatReturnsNull;
+      }
+    }
+
     function validate(props, propName, componentName, location, propFullName) {
       for (var i = 0; i < arrayOfTypeCheckers.length; i++) {
         var checker = arrayOfTypeCheckers[i];

--- a/factoryWithTypeCheckers.js
+++ b/factoryWithTypeCheckers.js
@@ -317,16 +317,13 @@ module.exports = function(isValidElement, throwOnDirectAccess) {
     for (var i = 0; i < arrayOfTypeCheckers.length; i++) {
       var checker = arrayOfTypeCheckers[i];
       if (typeof checker !== 'function') {
-        var detailMessage;
-
-        if(checker === void 0 || checker === null) {
-          detailMessage = checker;
-        }
-        else {
-          detailMessage = 'of type ' + getPreciseType(checker);
-        }
-
-        warning(false, 'Invalid argument supplied to oneOfType. Expected an array containing check functions, but argument at index ' + i + ' is ' + detailMessage + '.');
+        warning(
+          false,
+          'Invalid argument supplid to oneOfType. Expected an array of check functions, but ' +
+          'received %s at index %s.',
+          getPostfixForTypeWarning(checker),
+          i
+        );
         return emptyFunction.thatReturnsNull;
       }
     }
@@ -463,6 +460,9 @@ module.exports = function(isValidElement, throwOnDirectAccess) {
   // This handles more types than `getPropType`. Only used for error messages.
   // See `createPrimitiveTypeChecker`.
   function getPreciseType(propValue) {
+    if (typeof propValue === 'undefined' || propValue === null) {
+      return '' + propValue;
+    }
     var propType = getPropType(propValue);
     if (propType === 'object') {
       if (propValue instanceof Date) {
@@ -472,6 +472,23 @@ module.exports = function(isValidElement, throwOnDirectAccess) {
       }
     }
     return propType;
+  }
+
+  // Returns a string that is postfixed to a warning about an invalid type.
+  // For example, "undefined" or "of type array"
+  function getPostfixForTypeWarning(value) {
+    var type = getPreciseType(value);
+    switch (type) {
+      case 'array':
+      case 'object':
+        return 'an ' + type;
+      case 'boolean':
+      case 'date':
+      case 'regexp':
+        return 'a ' + type;
+      default:
+        return type;
+    }
   }
 
   // Returns class name of the object, if any.


### PR DESCRIPTION
PropTypes type checking: Add additional check to UnionType checker to ensure only functions are used as argument of oneOfType.

This is especially handy to catch typos during PropType definition like for example:
```javascript
Greeting.propTypes = {
  name: React.PropTypes.oneOfType([React.PropTypes.sting, React.PropTypes.func])
};
```

The pull request will print a warning 
`Invalid argument supplied to oneOfType, expected an array containing check functions.`

Pull Request taken over from React main Repository
https://github.com/facebook/react/pull/8823