### PR TITLE
Limit manual PropTypes call warning count

### DIFF
--- a/__tests__/PropTypesDevelopmentReact15.js
+++ b/__tests__/PropTypesDevelopmentReact15.js
@@ -93,6 +93,7 @@ function typeCheckPass(declaration, value) {
 }
 
 function expectWarningInDevelopment(declaration, value) {
+  resetWarningCache();
   var props = {testProp: value};
   var propName = 'testProp' + Math.random().toString();
   var componentName = 'testComponent' + Math.random().toString();

--- a/factoryWithTypeCheckers.js
+++ b/factoryWithTypeCheckers.js
@@ -148,6 +148,7 @@ module.exports = function(isValidElement, throwOnDirectAccess) {
   function createChainableTypeChecker(validate) {
     if (process.env.NODE_ENV !== 'production') {
       var manualPropTypeCallCache = {};
+      var manualPropTypeWarningCount = 0;
     }
     function checkType(isRequired, props, propName, componentName, location, propFullName, secret) {
       componentName = componentName || ANONYMOUS;
@@ -165,7 +166,11 @@ module.exports = function(isValidElement, throwOnDirectAccess) {
         } else if (process.env.NODE_ENV !== 'production' && typeof console !== 'undefined') {
           // Old behavior for people using React.PropTypes
           var cacheKey = componentName + ':' + propName;
-          if (!manualPropTypeCallCache[cacheKey]) {
+          if (
+            !manualPropTypeCallCache[cacheKey] &&
+            // Avoid spamming the console because they are often not actionable except for lib authors
+            manualPropTypeWarningCount < 3
+          ) {
             warning(
               false,
               'You are manually calling a React.PropTypes validation ' +
@@ -177,6 +182,7 @@ module.exports = function(isValidElement, throwOnDirectAccess) {
               componentName
             );
             manualPropTypeCallCache[cacheKey] = true;
+            manualPropTypeWarningCount++;
           }
         }
       }


### PR DESCRIPTION
We released `react@0.14.9` and `react-dom@0.14.9` that fix the false positive for this warning.

However I’m also limiting the number of times it gets printed so https://github.com/reactjs/react-redux/issues/669 is less annoying for people who haven’t updated yet.