### PR TITLE
README: Fixed typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -161,7 +161,7 @@ For libraries, we *also* recommend leaving it in `dependencies`:
 
 Make sure that the version range uses a caret (`^`) and thus is broad enough for npm to efficiently deduplicate packages.
 
-For UMD bundles of your comoponents, make sure you **don’t** include `PropTypes` in the build. Usually this is done by marking it as an external (the specifics depend on your bundler), just like you do with React.
+For UMD bundles of your components, make sure you **don’t** include `PropTypes` in the build. Usually this is done by marking it as an external (the specifics depend on your bundler), just like you do with React.
 
 ## Compatibility
 


### PR DESCRIPTION
Replaced 'comoponents' with 'components'