### PR TITLE
Fix false positive when mixing DEV and PROD builds

### DIFF
--- a/factoryWithThrowingShims.js
+++ b/factoryWithThrowingShims.js
@@ -11,11 +11,14 @@
 
 var emptyFunction = require('fbjs/lib/emptyFunction');
 var invariant = require('fbjs/lib/invariant');
+var ReactPropTypesSecret = require('./lib/ReactPropTypesSecret');
 
 module.exports = function() {
-  // Important!
-  // Keep this list in sync with production version in `./factoryWithTypeCheckers.js`.
-  function shim() {
+  function shim(props, propName, componentName, location, propFullName, secret) {
+    if (secret === ReactPropTypesSecret) {
+      // It is still safe when called from React.
+      return;
+    }
     invariant(
       false,
       'Calling PropTypes validators directly is not supported by the `prop-types` package. ' +
@@ -27,6 +30,8 @@ module.exports = function() {
   function getShim() {
     return shim;
   };
+  // Important!
+  // Keep this list in sync with production version in `./factoryWithTypeCheckers.js`.
   var ReactPropTypes = {
     array: shim,
     bool: shim,


### PR DESCRIPTION
When a library bundles a PROD build of `prop-types`, but it is used with a DEV version of React, we print a false positive error message:

>Failed prop type: React.PropTypes type checking code is stripped in production

This fixes it by checking the secret even in the production build.
Fixes https://github.com/reactjs/prop-types/issues/38.